### PR TITLE
feat(almacen): implementar formateo automático de codigoComprobante en mapper

### DIFF
--- a/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/mapper/OrdenSalidaDevolucionResponseMapper.java
+++ b/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/mapper/OrdenSalidaDevolucionResponseMapper.java
@@ -1,18 +1,17 @@
 package com.walrex.module_almacen.infrastructure.adapters.inbound.reactiveweb.mapper;
 
+import org.mapstruct.*;
+
 import com.walrex.module_almacen.domain.model.OrdenSalidaDevolucionDTO;
 import com.walrex.module_almacen.infrastructure.adapters.inbound.reactiveweb.response.OrdenSalidaDevolucionResponse;
-import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
 /**
- * Mapper para convertir OrdenSalidaDevolucionDTO a OrdenSalidaDevolucionResponse.
- * Utiliza MapStruct para generar automáticamente las implementaciones de mapeo.
- * MapStruct generará automáticamente métodos para listas basándose en el método individual.
+ * Mapper para convertir OrdenSalidaDevolucionDTO a
+ * OrdenSalidaDevolucionResponse.
  */
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface OrdenSalidaDevolucionResponseMapper {
-    
+
     /**
      * Convierte un OrdenSalidaDevolucionDTO a OrdenSalidaDevolucionResponse.
      * 
@@ -21,4 +20,29 @@ public interface OrdenSalidaDevolucionResponseMapper {
      */
     OrdenSalidaDevolucionResponse toResponse(OrdenSalidaDevolucionDTO dto);
 
-} 
+    /**
+     * Formatea el código del comprobante después del mapeo.
+     * Concatena: numeroSerie + '-' + numeroComprobante (rellenado con ceros hasta 8
+     * caracteres)
+     * 
+     * @param dto      el DTO de origen
+     * @param response el response de destino
+     */
+    @AfterMapping
+    default void formatearCodigoComprobante(OrdenSalidaDevolucionDTO dto,
+            @MappingTarget OrdenSalidaDevolucionResponse response) {
+        if (dto.getNumeroComprobante() != null && !dto.getNumeroComprobante().trim().isEmpty()) {
+            String numeroSerie = dto.getNumeroSerie() != null ? dto.getNumeroSerie() : "";
+            String numeroComprobante = dto.getNumeroComprobante().trim();
+
+            // Rellenar con ceros hasta 8 caracteres
+            String numeroComprobanteFormateado = String.format("%08d",
+                    Integer.parseInt(numeroComprobante));
+
+            // Concatenar: numeroSerie + '-' + numeroComprobante
+            String codigoComprobante = numeroSerie + "-" + numeroComprobanteFormateado;
+
+            response.setCodigoComprobante(codigoComprobante);
+        }
+    }
+}

--- a/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/response/OrdenSalidaDevolucionResponse.java
+++ b/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/response/OrdenSalidaDevolucionResponse.java
@@ -42,10 +42,10 @@ public class OrdenSalidaDevolucionResponse {
     @Schema(description = "ID del comprobante", example = "1234")
     private Long idComprobante;
 
-    @Schema(description = "Número de serie del comprobante", example = "001")
+    @Schema(description = "Número de serie del comprobante", example = "T001")
     private String numeroSerie;
 
-    @Schema(description = "Número del comprobante", example = "GU-2024-001")
+    @Schema(description = "Número del comprobante", example = "1")
     private String numeroComprobante;
 
     @Schema(description = "Tipo de serie del comprobante", example = "5")
@@ -54,4 +54,7 @@ public class OrdenSalidaDevolucionResponse {
     @Schema(description = "Fecha de comunicación del comprobante", example = "2024-01-15")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate fecComunicacion;
+
+    @Schema(description = "Codigo del comprobante", example = "T001-00000001")
+    private String codigoComprobante;
 }


### PR DESCRIPTION
## 🎯 Objetivo

Implementar formateo automático del campo  en el mapper de respuestas de órdenes de salida por devolución.

## 🔧 Funcionalidad Implementada

### @AfterMapping en OrdenSalidaDevolucionResponseMapper

- **Formateo automático**: Concatena 
- **Rellenado con ceros**: Formatea  hasta 8 caracteres
- **Validaciones seguras**: Manejo de valores null y vacíos
- **Ejecución automática**: Se ejecuta después del mapeo principal

### Ejemplos de Formateo



## ✅ Cambios Implementados

### Mapper Improvements
- **@AfterMapping**: Función  agregada
- **Validaciones**: Verificación de null y strings vacíos
- **Formato consistente**: 8 dígitos con relleno de ceros
- **Concatenación segura**: Manejo de valores null en numeroSerie

### Code Quality
- **Imports optimizados**: Wildcard import para MapStruct
- **Documentación mejorada**: Comentarios descriptivos
- **Manejo de errores**: Validaciones robustas

## 🛡️ Beneficios

- ✅ **Formato consistente** para códigos de comprobante
- ✅ **Automatización** del formateo en el mapper
- ✅ **Validaciones seguras** para datos de entrada
- ✅ **Mantenibilidad** con código limpio y documentado
- ✅ **Escalabilidad** para futuros formatos

## 📊 Impacto

- **Consistencia**: Formato uniforme en todas las respuestas
- **Automatización**: Sin necesidad de formateo manual
- **Calidad**: Validaciones robustas de datos
- **Performance**: Formateo eficiente en el mapper