### PR TITLE
fix(almacen): corregir JOIN incorrecto en query de órdenes de salida

### DIFF
--- a/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/mapper/OrdenSalidaDevolucionResponseMapper.java
+++ b/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/mapper/OrdenSalidaDevolucionResponseMapper.java
@@ -1,18 +1,17 @@
 package com.walrex.module_almacen.infrastructure.adapters.inbound.reactiveweb.mapper;
 
+import org.mapstruct.*;
+
 import com.walrex.module_almacen.domain.model.OrdenSalidaDevolucionDTO;
 import com.walrex.module_almacen.infrastructure.adapters.inbound.reactiveweb.response.OrdenSalidaDevolucionResponse;
-import org.mapstruct.Mapper;
-import org.mapstruct.ReportingPolicy;
 
 /**
- * Mapper para convertir OrdenSalidaDevolucionDTO a OrdenSalidaDevolucionResponse.
- * Utiliza MapStruct para generar automáticamente las implementaciones de mapeo.
- * MapStruct generará automáticamente métodos para listas basándose en el método individual.
+ * Mapper para convertir OrdenSalidaDevolucionDTO a
+ * OrdenSalidaDevolucionResponse.
  */
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface OrdenSalidaDevolucionResponseMapper {
-    
+
     /**
      * Convierte un OrdenSalidaDevolucionDTO a OrdenSalidaDevolucionResponse.
      * 
@@ -21,4 +20,29 @@ public interface OrdenSalidaDevolucionResponseMapper {
      */
     OrdenSalidaDevolucionResponse toResponse(OrdenSalidaDevolucionDTO dto);
 
-} 
+    /**
+     * Formatea el código del comprobante después del mapeo.
+     * Concatena: numeroSerie + '-' + numeroComprobante (rellenado con ceros hasta 8
+     * caracteres)
+     * 
+     * @param dto      el DTO de origen
+     * @param response el response de destino
+     */
+    @AfterMapping
+    default void formatearCodigoComprobante(OrdenSalidaDevolucionDTO dto,
+            @MappingTarget OrdenSalidaDevolucionResponse response) {
+        if (dto.getNumeroComprobante() != null && !dto.getNumeroComprobante().trim().isEmpty()) {
+            String numeroSerie = dto.getNumeroSerie() != null ? dto.getNumeroSerie() : "";
+            String numeroComprobante = dto.getNumeroComprobante().trim();
+
+            // Rellenar con ceros hasta 8 caracteres
+            String numeroComprobanteFormateado = String.format("%08d",
+                    Integer.parseInt(numeroComprobante));
+
+            // Concatenar: numeroSerie + '-' + numeroComprobante
+            String codigoComprobante = numeroSerie + "-" + numeroComprobanteFormateado;
+
+            response.setCodigoComprobante(codigoComprobante);
+        }
+    }
+}

--- a/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/response/OrdenSalidaDevolucionResponse.java
+++ b/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/inbound/reactiveweb/response/OrdenSalidaDevolucionResponse.java
@@ -42,10 +42,10 @@ public class OrdenSalidaDevolucionResponse {
     @Schema(description = "ID del comprobante", example = "1234")
     private Long idComprobante;
 
-    @Schema(description = "Número de serie del comprobante", example = "001")
+    @Schema(description = "Número de serie del comprobante", example = "T001")
     private String numeroSerie;
 
-    @Schema(description = "Número del comprobante", example = "GU-2024-001")
+    @Schema(description = "Número del comprobante", example = "1")
     private String numeroComprobante;
 
     @Schema(description = "Tipo de serie del comprobante", example = "5")
@@ -54,4 +54,7 @@ public class OrdenSalidaDevolucionResponse {
     @Schema(description = "Fecha de comunicación del comprobante", example = "2024-01-15")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate fecComunicacion;
+
+    @Schema(description = "Codigo del comprobante", example = "T001-00000001")
+    private String codigoComprobante;
 }

--- a/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/outbound/persistence/DevolucionRollosPersistenceAdapter.java
+++ b/module-almacen/src/main/java/com/walrex/module_almacen/infrastructure/adapters/outbound/persistence/DevolucionRollosPersistenceAdapter.java
@@ -368,7 +368,7 @@ public class DevolucionRollosPersistenceAdapter implements DevolucionRollosPort,
                                 INNER JOIN almacenes.devolucion_servicios d ON d.id_ordensalida = ords.id_ordensalida
                                 LEFT JOIN comercial.tbclientes tbc ON tbc.id_cliente = ords.id_cliente
                                 LEFT JOIN facturacion.tbcomprobantes compr ON compr.id_comprobante = d.id_comprobante
-                                LEFT JOIN facturacion.tipo_serie tip_ser ON tip_ser.id_compro = compr.tctipo_serie
+                                LEFT JOIN facturacion.tipo_serie tip_ser ON tip_ser.id_serie = compr.tctipo_serie
                                 WHERE ords.id_almacen_origen = 8 AND ords.id_motivo = 33
                                 """);
 


### PR DESCRIPTION
## 🐛 Problema Identificado

El JOIN incorrecto en la query de órdenes de salida causaba que  llegara como , impidiendo que el  funcionara correctamente para formatear .

## 🔧 Corrección Implementada

### Query SQL Corregida
- **Antes**: 
- **Después**: 

### Impacto de la Corrección
- ✅ **numeroSerie** ahora se obtiene correctamente desde la BD
- ✅ **@AfterMapping** puede formatear  correctamente
- ✅ **Frontend** puede validar  para habilitar Lycet
- ✅ **Consistencia** de datos entre módulos mejorada

## 🧪 Testing

### Antes de la Corrección


### Después de la Corrección


## �� Beneficios

- **Formateo automático** de códigos de comprobante
- **Validación correcta** de  en frontend
- **Integración Lycet** funcionando correctamente
- **Datos consistentes** entre módulos