### PR TITLE
fix(partidas): agregar binding del parámetro lote en AlmacenesRepository

### DIFF
--- a/module-partidas/src/main/java/com/walrex/module_partidas/infrastructure/adapters/outbound/persistence/repository/AlmacenesRepository.java
+++ b/module-partidas/src/main/java/com/walrex/module_partidas/infrastructure/adapters/outbound/persistence/repository/AlmacenesRepository.java
@@ -80,6 +80,7 @@ public class AlmacenesRepository {
                 .bind("idArticulo", idArticulo)
                 .bind("idUnidad", idUnidad)
                 .bind("pesoRef", pesoRef)
+                .bind("lote", lote)
                 .bind("nuRollos", nuRollos)
                 .bind("idComprobante", idComprobante)
                 .map((row, metadata) -> row.get("id_detordeningreso", Integer.class))


### PR DESCRIPTION
## Fix: Parámetro lote faltante en AlmacenesRepository

### Problema identificado

El método de inserción en  tenía un parámetro  faltante en el binding de la query, lo que podría causar errores en la inserción de datos.

### Solución implementada

- **Agregar binding**: `.bind("lote", lote)` en la query de inserción
- **Ubicación**: Entre `pesoRef` y `nuRollos` para mantener orden lógico
- **Compatibilidad**: Mantiene funcionalidad existente sin breaking changes

### Cambio técnico

```diff
.bind("pesoRef", pesoRef)
+.bind("lote", lote)
.bind("nuRollos", nuRollos)
```

### Impacto

- **Archivo modificado**: 1 archivo
- **Líneas agregadas**: +1 línea
- **Funcionalidad**: Corrige inserción de registros con parámetro lote

### Checklist

- [x] Binding del parámetro lote agregado correctamente
- [x] Orden de parámetros mantenido
- [x] No breaking changes introducidos
- [x] Funcionalidad existente preservada

### Testing

- [ ] Verificar inserción de registros con lote
- [ ] Validar que no se rompan inserciones existentes
- [ ] Probar funcionalidad completa de AlmacenesRepository

### Notas

Este fix corrige un parámetro que probablemente se agregó al modelo pero no se incluyó en la query de inserción, causando inconsistencias en los datos almacenados.