### PR TITLE
fix(config): expandir variables de entorno en application-docker.yml

### DIFF
--- a/module-core/src/main/resources/application-docker.yml
+++ b/module-core/src/main/resources/application-docker.yml
@@ -255,7 +255,7 @@ spring:
     proxy-target-class: true
 websocket:
   api:
-    url: http://{HOST_API_WEBSOCKET}:{PORT_API_WEBSOCKET}/api/ws
+    url: http://${HOST_API_WEBSOCKET}:${PORT_API_WEBSOCKET}/api/ws
   module:
     port: 9093
     max-connections: 100
@@ -321,7 +321,7 @@ springdoc:
 lycet:
   api:
     token: EXnPrun0IjhqwyZaNSWLZpeJ9y1ktZOJ
-    base-url: http://{HOST_API_LYCET}:{PORT_API_LYCET}/api/v1
+    base-url: http://${HOST_API_LYCET}:${PORT_API_LYCET}/api/v1
     endpoint-despatch: /despatch/send
     timeout: 30
 logging:


### PR DESCRIPTION
## Descripción
Este PR corrige la expansión de variables de entorno en el archivo de configuración Docker.

## Cambios realizados
- Cambiar `{HOST_API_WEBSOCKET}` por `${HOST_API_WEBSOCKET}` en websocket.api.url
- Cambiar `{PORT_API_WEBSOCKET}` por `${PORT_API_WEBSOCKET}` en websocket.api.url  
- Cambiar `{HOST_API_LYCET}` por `${HOST_API_LYCET}` en lycet.api.base-url
- Cambiar `{PORT_API_LYCET}` por `${PORT_API_LYCET}` en lycet.api.base-url

## Problema resuelto
Las variables de entorno no se expandían correctamente en Docker debido al uso de llaves simples `{}` en lugar de la sintaxis correcta `${}` para Spring Boot.

## Tipo de cambio
- [x] Bug fix (cambio que corrige un problema)
- [ ] Nueva funcionalidad (cambio que agrega funcionalidad)
- [ ] Breaking change (cambio que causa que la funcionalidad existente no funcione como se esperaba)

## Testing
- [x] Verificado que las variables se expandan correctamente en Docker
- [x] No hay cambios en la funcionalidad existente