### PR TITLE
fix(gateway): agregar ACL token de Consul y actualizar Spring Cloud 2024.0.1

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -36,7 +36,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<spring-cloud.version>2024.0.1</spring-cloud.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<logback.version>1.5.8</logback.version>
 		<logstash.version>8.0</logstash.version>

--- a/module-core/src/main/resources/application-docker.yml
+++ b/module-core/src/main/resources/application-docker.yml
@@ -142,6 +142,7 @@ spring:
       discovery:
         enabled: true
         register: false
+        acl-token: ${GATEWAY_TOKEN}
         health-check-path: /actuator/health
         health-check-internal: 15s
         instance-id: ${spring.application.name}-${random.value}


### PR DESCRIPTION
Closes #39

## Resumen

- Agrega `acl-token: ${GATEWAY_TOKEN}` en `application-docker.yml` para autenticación ACL con Consul
- Actualiza `spring-cloud.version` de `2024.0.0` → `2024.0.1` en `gateway/pom.xml`

## Motivación

En entornos Docker con Consul ACL habilitado, el gateway fallaba al registrarse por no enviar el token de autenticación. Adicionalmente, `2024.0.0` presentaba incompatibilidades con Spring Boot 3.4.x corregidas en el patch `2024.0.1`.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `module-core/src/main/resources/application-docker.yml` | Agrega `acl-token: ${GATEWAY_TOKEN}` en config Consul |
| `gateway/pom.xml` | Actualiza `spring-cloud.version` a `2024.0.1` |

## Variables de entorno requeridas

| Variable | Descripción |
|----------|-------------|
| `GATEWAY_TOKEN` | Token ACL de Consul para el servicio gateway |

## Plan de pruebas

- [ ] Desplegar en entorno Docker con Consul ACL habilitado
- [ ] Verificar que el gateway se registra correctamente en Consul (`consul catalog services`)
- [ ] Confirmar que no hay errores de autenticación en los logs al iniciar
- [ ] Validar que el health-check de Consul responde correctamente