### PR TITLE
fix(gateway): agregar propiedades consul.base-url y consul.token faltantes en configuración

### DIFF
--- a/gateway/src/main/resources/application-dev.yml
+++ b/gateway/src/main/resources/application-dev.yml
@@ -14,6 +14,11 @@ spring:
     validate-on-migrate: true
     out-of-order: false
 
+consul:
+  base-url: http://${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}
+  token: ${GATEWAY_TOKEN:dev-token}
+  datacenter: ${CONSUL_DATACENTER:dc1}
+
 logging:
   file:
     path: ./logs

--- a/module-core/src/main/resources/application-docker.yml
+++ b/module-core/src/main/resources/application-docker.yml
@@ -287,6 +287,11 @@ flyway:
   modules:
     enabled: true
     verbose: true
+
+consul:
+  base-url: http://${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}
+  token: ${GATEWAY_TOKEN}
+  datacenter: ${CONSUL_DATACENTER:dc1}
 reactor:
   tools:
     agent:


### PR DESCRIPTION
## Problema

Al desplegar la imagen `v1.11.0`, la aplicación falla en startup con:

```
PlaceholderResolutionException: Could not resolve placeholder 'consul.base-url'
```

`ConsulWebClientConfig` requiere `consul.base-url` y `consul.token` como propiedades propias, pero estos valores no estaban definidos en ningún perfil de configuración — solo existía la configuración de Spring Cloud Consul bajo `spring.cloud.consul.*`.

## Causa raíz

El bloque `consul:` con `base-url` y `token` fue añadido al código pero no se propagó a los archivos de configuración de los perfiles `docker` y `dev`.

## Solución

| Archivo | Cambio |
|---------|--------|
| `application-docker.yml` | Agrega `consul.base-url`, `consul.token` y `consul.datacenter` usando las variables de entorno existentes `CONSUL_HOST`, `CONSUL_PORT`, `GATEWAY_TOKEN` |
| `application-dev.yml` | Agrega el mismo bloque con valores por defecto para desarrollo local (`dev-token` como fallback de `GATEWAY_TOKEN`) |

## Configuración resultante

```yaml
consul:
  base-url: http://${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}
  token: ${GATEWAY_TOKEN}          # obligatorio en docker, fallback en dev
  datacenter: ${CONSUL_DATACENTER:dc1}
```

## Plan de pruebas

- [ ] Verificar que el contenedor arranca sin errores con `GATEWAY_TOKEN` configurado
- [ ] Verificar que el bean `consulWebClient` se crea correctamente
- [ ] Confirmar que el gateway resuelve servicios en Consul