### PR TITLE
fix(gateway): configurar timeouts de conexión y lectura en WebClient de Consul

### DIFF
--- a/gateway/src/main/java/com/walrex/gateway/gateway/infrastructure/adapters/outbound/consul/ConsulWebClientConfig.java
+++ b/gateway/src/main/java/com/walrex/gateway/gateway/infrastructure/adapters/outbound/consul/ConsulWebClientConfig.java
@@ -1,10 +1,16 @@
 package com.walrex.gateway.gateway.infrastructure.adapters.outbound.consul;
 
-import org.springframework.http.HttpHeaders;
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import io.netty.channel.ChannelOption;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class ConsulWebClientConfig {
@@ -13,9 +19,16 @@ public class ConsulWebClientConfig {
     WebClient consulWebClient(
         WebClient.Builder builder,
         @Value("${consul.base-url}") String baseUrl,
-        @Value("${consul.token}") String token
+        @Value("${consul.token}") String token,
+        @Value("${consul.connect-timeout-ms:2000}") int connectTimeoutMs,
+        @Value("${consul.read-timeout-ms:3000}") int readTimeoutMs
     ) {
+        HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
+            .responseTimeout(Duration.ofMillis(readTimeoutMs));
+
         return builder
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
             .baseUrl(baseUrl)
             .defaultHeaders(h -> {
                 h.set("X-Consul-Token", token);


### PR DESCRIPTION
## Descripción

Configuración de timeouts a nivel de transporte en el `WebClient` que consulta Consul.

Closes #48

## Cambio

```java
// Antes
return builder
    .baseUrl(baseUrl)
    .defaultHeaders(...)
    .build();

// Después
HttpClient httpClient = HttpClient.create()
    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
    .responseTimeout(Duration.ofMillis(readTimeoutMs));

return builder
    .clientConnector(new ReactorClientHttpConnector(httpClient))
    .baseUrl(baseUrl)
    .defaultHeaders(...)
    .build();
```

## Propiedades nuevas

| Propiedad | Default | Descripción |
|-----------|---------|-------------|
| `consul.connect-timeout-ms` | `2000` | Timeout de conexión TCP a Consul |
| `consul.read-timeout-ms` | `3000` | Timeout de respuesta HTTP de Consul |